### PR TITLE
Add type definitions for gifenc module

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "./.wxt/tsconfig.json",
   "compilerOptions": {
     "allowImportingTsExtensions": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "typeRoots": ["./types", "./node_modules/@types"]
   }
 }

--- a/types/gifenc.d.ts
+++ b/types/gifenc.d.ts
@@ -1,0 +1,46 @@
+declare module 'gifenc' {
+  export class GIFEncoder {
+    constructor(options?: { auto?: boolean; initialCapacity?: number });
+    reset(): void;
+    setDelay(delay: number): void;
+    setRepeat(repeat: number): void;
+    setTransparent(color: number | false): void;
+    addFrame(
+      ctx: CanvasRenderingContext2D,
+      options?: {
+        copy?: boolean;
+        delay?: number;
+        palette?: number[][] | null;
+        transparent?: boolean;
+        disposal?: number;
+      }
+    ): void;
+    finish(): void;
+    bytes(): Uint8Array;
+    bytesView(): Uint8Array;
+    stream(): ReadableStream<Uint8Array>;
+    write(chunk: Uint8Array): void;
+    end(): void;
+  }
+
+  export function quantize(
+    pixels: Uint8Array | Uint8ClampedArray,
+    maxColors: number,
+    options?: {
+      format?: 'rgb565' | 'rgb444' | 'rgba4444';
+      oneBitAlpha?: boolean | number;
+      clearAlpha?: boolean;
+      clearAlphaThreshold?: number;
+      clearAlphaColor?: number;
+      palette?: number[][];
+    }
+  ): number[][];
+
+  export function applyPalette(
+    pixels: Uint8Array | Uint8ClampedArray,
+    palette: number[][],
+    options?: {
+      format?: 'rgb565' | 'rgb444' | 'rgba4444';
+    }
+  ): Uint8Array;
+}


### PR DESCRIPTION
Created a new `gifenc.d.ts` file in the `types` directory to provide type definitions for the `gifenc` module. This resolves TypeScript errors related to missing type information.

Updated `tsconfig.json` to include the new `types` directory in `typeRoots` so that TypeScript can discover these custom type definitions.