### PR TITLE
feat: Add buttons to set start/duration from video time

### DIFF
--- a/src/components/ConfigurationPanel/ConfigurationPanel.test.tsx
+++ b/src/components/ConfigurationPanel/ConfigurationPanel.test.tsx
@@ -1,7 +1,11 @@
 import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { vi, describe, beforeEach, test, expect } from 'vitest';
 import ConfigurationPanel from './ConfigurationPanel'; // Adjust path if necessary
 import { secondsToTimecode } from '@/utils/secondsToTimecode'; // Helper for assertions
+// Mocked icons that would be used by the buttons
+// vi.mock('@/assets/arrow-right.svg?react', () => ({ default: () => 'ArrowRightIcon' }));
+// vi.mock('@/assets/arrow-down.svg?react', () => ({ default: () => 'ArrowDownIcon' }));
 
 // Mock the useAppStore
 vi.mock('@/stores/appStore', () => {
@@ -185,4 +189,123 @@ describe('ConfigurationPanel', () => {
     // InputTime component formats with one decimal for seconds (e.g., "0:03.0")
     expect(startTimeInput.value).toBe(`${secondsToTimecode(3)}.0`);
   });
+
+  describe('Append Buttons Functionality', () => {
+    test('clicking "Set start to current time" button updates start time input', async () => {
+      mockVideoElement.currentTime = 15.5; // Video's current time
+      mockAppStoreState.videoElement = mockVideoElement;
+      (
+        actualAppStore.useAppStore.getState as ReturnType<typeof vi.fn>
+      ).mockReturnValue(mockAppStoreState);
+      // @ts-ignore
+      (
+        actualAppStore.useAppStore as ReturnType<typeof vi.fn>
+      ).mockImplementation((selector) => selector(mockAppStoreState));
+
+      render(<ConfigurationPanel onSubmit={vi.fn()} />);
+
+      const setStartTimeButton = screen.getByLabelText(
+        'Set start to current time'
+      );
+      await userEvent.click(setStartTimeButton);
+
+      const startTimeInput = screen.getByLabelText('Start') as HTMLInputElement;
+      // InputTime formats to M:SS.s, e.g., 0:15.5
+      expect(startTimeInput.value).toBe(
+        secondsToHMSsForTest(15.5, 1) // Assuming step 0.1 for start time
+      );
+    });
+
+    test('clicking "Set duration to current time" button updates duration input', async () => {
+      mockVideoElement.currentTime = 25.0; // Video's current time
+      mockAppStoreState.videoElement = mockVideoElement;
+      // Initial start time for the panel state will be 0 unless set otherwise
+      // Let's assume panel's initial start time is 5s for this test.
+      // We need to simulate the panel's internal state for 'start' being 5.
+      // The easiest way is to first set the start time via its button or input change.
+
+      const { rerender } = render(<ConfigurationPanel onSubmit={vi.fn()} />);
+
+      // Simulate setting start time to 5s
+      // First, set video current time to 5s and click the "set start" button
+      mockVideoElement.currentTime = 5.0;
+      await userEvent.click(screen.getByLabelText('Set start to current time'));
+      // At this point, the panel's internal state for 'start' should be 5.0
+
+      // Now, set video current time to 25s for duration calculation
+      mockVideoElement.currentTime = 25.0;
+      // Rerender or ensure state update if necessary;
+      // for this direct button click leading to dispatch, it should be fine.
+
+      const setDurationButton = screen.getByLabelText(
+        'Set duration to current time'
+      );
+      await userEvent.click(setDurationButton);
+
+      const durationInput = screen.getByLabelText(
+        'Duration'
+      ) as HTMLInputElement;
+      // Expected duration = 25.0 (current) - 5.0 (start) = 20.0
+      expect(durationInput.value).toBe('20'); // InputNumber shows plain number
+    });
+
+    test('"Set duration to current time" does nothing if current time is before start time', async () => {
+      mockVideoElement.currentTime = 2.0; // Video's current time, before start
+      mockAppStoreState.videoElement = mockVideoElement;
+
+      render(<ConfigurationPanel onSubmit={vi.fn()} />);
+
+      // Simulate setting start time to 5s
+      mockVideoElement.currentTime = 5.0;
+      await userEvent.click(screen.getByLabelText('Set start to current time'));
+      const durationInput = screen.getByLabelText(
+        'Duration'
+      ) as HTMLInputElement;
+      const initialDuration = durationInput.value; // Should be default '2'
+
+      // Now, set video current time to be BEFORE start time (e.g., 2s)
+      mockVideoElement.currentTime = 2.0;
+
+      const setDurationButton = screen.getByLabelText(
+        'Set duration to current time'
+      );
+      await userEvent.click(setDurationButton);
+
+      expect(durationInput.value).toBe(initialDuration); // Duration should not change
+    });
+  });
 });
+
+// Helper function to mimic secondsToHMSs formatting for test assertions,
+// as it's internal to InputTime.
+// This is a simplified version for clarity.
+const secondsToHMSsForTest = (
+  totalSeconds: number,
+  decimalPlaces: number
+): string => {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const pad = (num: number) => String(num).padStart(2, '0');
+
+  let formattedSeconds = seconds.toFixed(decimalPlaces);
+  // Ensure seconds part is padded if it becomes like "5.0" -> "05.0" when minutes > 0 or hours > 0
+  if ((hours > 0 || minutes > 0) && formattedSeconds.indexOf('.') !== -1) {
+    const [secInt, secDec] = formattedSeconds.split('.');
+    formattedSeconds = `${pad(parseInt(secInt, 10))}.${secDec}`;
+  } else if (
+    (hours > 0 || minutes > 0) &&
+    formattedSeconds.indexOf('.') === -1
+  ) {
+    formattedSeconds = pad(parseInt(formattedSeconds, 10));
+  }
+
+  if (hours > 0) {
+    return `${hours}:${pad(minutes)}:${formattedSeconds}`;
+  }
+  return `${minutes}:${formattedSeconds.padStart(
+    2 + (decimalPlaces > 0 ? decimalPlaces + 1 : 0),
+    '0'
+  )}`;
+};

--- a/src/components/InputNumber/InputNumber.module.css
+++ b/src/components/InputNumber/InputNumber.module.css
@@ -1,5 +1,16 @@
+.appendContainer {
+  display: flex;
+  align-items: center;
+  gap: 4px; /* Adjust as needed */
+}
+
+.appendButton {
+  /* Specific styles for InputNumber's append button, if different from InputTime */
+}
+
 .buttonGrid {
   display: flex;
   flex-direction: column;
   justify-content: center;
+  /* Ensure it doesn't conflict with appendContainer flex properties */
 }

--- a/src/components/InputNumber/InputNumber.test.tsx
+++ b/src/components/InputNumber/InputNumber.test.tsx
@@ -165,4 +165,110 @@ describe('InputNumber', () => {
     expect(screen.getByText('▲').closest('button')?.disabled).toBe(true);
     expect(screen.getByText('▼').closest('button')?.disabled).toBe(true);
   });
+
+  describe('Append Button Specific Tests for InputNumber', () => {
+    const defaultProps = {
+      name: 'test-input',
+      label: 'Test Input',
+      value: '0',
+      onChange: vi.fn()
+    };
+
+    beforeEach(() => {
+      defaultProps.onChange.mockClear();
+    });
+
+    it('renders append button when icon and handler are provided', () => {
+      const handleAppendClick = vi.fn();
+      const icon = <span>ICON</span>;
+      render(
+        <InputNumber
+          {...defaultProps}
+          appendButtonIcon={icon}
+          onAppendButtonClick={handleAppendClick}
+          appendButtonLabel="Test Append"
+        />
+      );
+      const appendButton = screen.getByLabelText('Test Append');
+      expect(appendButton).toBeDefined();
+      expect(appendButton.textContent).toBe('ICON');
+    });
+
+    it('does not render append button if icon is missing', () => {
+      const handleAppendClick = vi.fn();
+      render(
+        <InputNumber
+          {...defaultProps}
+          onAppendButtonClick={handleAppendClick}
+          appendButtonLabel="Test Append No Icon"
+        />
+      );
+      expect(screen.queryByLabelText('Test Append No Icon')).toBeNull();
+    });
+
+    it('does not render append button if handler is missing', () => {
+      const icon = <span>ICON</span>;
+      render(
+        <InputNumber
+          {...defaultProps}
+          appendButtonIcon={icon}
+          appendButtonLabel="Test Append No Handler"
+        />
+      );
+      expect(screen.queryByLabelText('Test Append No Handler')).toBeNull();
+    });
+
+    it('calls onAppendButtonClick when append button is clicked', async () => {
+      const handleAppendClick = vi.fn();
+      const icon = <span>ICON</span>;
+      render(
+        <InputNumber
+          {...defaultProps}
+          appendButtonIcon={icon}
+          onAppendButtonClick={handleAppendClick}
+          appendButtonLabel="Clickable Append"
+        />
+      );
+      const appendButton = screen.getByLabelText('Clickable Append');
+      await userEvent.click(appendButton);
+      expect(handleAppendClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('append button is disabled when InputNumber is disabled', () => {
+      const handleAppendClick = vi.fn();
+      const icon = <span>ICON</span>;
+      render(
+        <InputNumber
+          {...defaultProps}
+          appendButtonIcon={icon}
+          onAppendButtonClick={handleAppendClick}
+          appendButtonLabel="Disabled Append"
+          disabled={true}
+        />
+      );
+      const appendButton = screen.getByLabelText(
+        'Disabled Append'
+      ) as HTMLButtonElement;
+      expect(appendButton.disabled).toBe(true);
+    });
+
+    it('renders existing append content alongside the new append button', () => {
+      const handleAppendClick = vi.fn();
+      const icon = <span>ICON</span>;
+      render(
+        <InputNumber
+          {...defaultProps}
+          appendButtonIcon={icon}
+          onAppendButtonClick={handleAppendClick}
+          appendButtonLabel="Test Append"
+          append={<span data-testid="original-append">Original</span>}
+        />
+      );
+      expect(screen.getByLabelText('Test Append')).toBeDefined();
+      expect(screen.getByTestId('original-append')).toBeDefined();
+      expect(screen.getByTestId('original-append').textContent).toBe(
+        'Original'
+      );
+    });
+  });
 });

--- a/src/components/InputNumber/InputNumber.tsx
+++ b/src/components/InputNumber/InputNumber.tsx
@@ -12,7 +12,10 @@ interface InputNumberProps extends InputProps {
   label: React.ReactNode;
   value: string;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  append?: React.ReactNode;
+  append?: React.ReactNode; // Existing append for things like steppers
+  onAppendButtonClick?: () => void;
+  appendButtonIcon?: React.ReactNode;
+  appendButtonLabel?: string;
 }
 
 export function InputNumber({
@@ -20,7 +23,10 @@ export function InputNumber({
   label,
   value,
   onChange,
-  append,
+  append, // This will be the stepper controls passed from outside if needed, or similar
+  onAppendButtonClick,
+  appendButtonIcon,
+  appendButtonLabel = 'Append button',
   ...restProps
 }: InputNumberProps) {
   const inputRef: React.RefObject<HTMLInputElement | null> = useRef(null);
@@ -41,37 +47,65 @@ export function InputNumber({
     inputRef.current?.dispatchEvent(event);
   }
 
-  const controls = (
-    <>
-      <div
-        className={css.buttonGrid} // Use CSS Module class
+  const stepperControls = (
+    <div
+      className={css.buttonGrid} // Use CSS Module class
+    >
+      <Button
+        size="x-small"
+        variant="ghost"
+        padding="none"
+        onClick={handleUpClick}
+        disabled={restProps.disabled}>
+        ▲
+      </Button>
+      <Button
+        size="x-small"
+        variant="ghost"
+        padding="none"
+        onClick={handleDownClick}
+        disabled={restProps.disabled}>
+        ▼
+      </Button>
+    </div>
+  );
+
+  const appendElements: React.ReactNode[] = [];
+
+  if (onAppendButtonClick && appendButtonIcon) {
+    appendElements.push(
+      <Button
+        key="custom-append-button"
+        size="x-small"
+        variant="ghost"
+        padding="none"
+        onClick={onAppendButtonClick}
+        disabled={restProps.disabled}
+        aria-label={appendButtonLabel}
+        className={css.appendButton} // Assuming similar styling to InputTime
       >
-        <Button
-          size="x-small"
-          variant="ghost"
-          padding="none"
-          onClick={handleUpClick}
-          disabled={restProps.disabled}>
-          ▲
-        </Button>
-        <Button
-          size="x-small"
-          variant="ghost"
-          padding="none"
-          onClick={handleDownClick}
-          disabled={restProps.disabled}>
-          ▼
-        </Button>
-      </div>
-      {append}
-    </>
+        {appendButtonIcon}
+      </Button>
+    );
+  }
+
+  // Add the standard stepper controls
+  appendElements.push(stepperControls);
+
+  // Add any other append content passed via props
+  if (append) {
+    appendElements.push(append);
+  }
+
+  const combinedAppend = (
+    <div className={css.appendContainer}>{appendElements}</div>
   );
 
   return (
     <Input
       name={name}
       label={label}
-      append={controls}
+      append={combinedAppend}
       value={value}
       onChange={onChange}
       type="number"

--- a/src/components/InputTime/InputTime.module.css
+++ b/src/components/InputTime/InputTime.module.css
@@ -1,5 +1,15 @@
+.appendContainer {
+  display: flex;
+  align-items: center;
+  gap: 4px; /* Adjust as needed */
+}
+
+.appendButton {
+  /* Add any specific styles for the new button if needed */
+  /* For example, if it needs different padding or margin than steppers */
+}
+
 .stepper {
   display: flex;
   flex-direction: column;
-  justify-content: center;
 }

--- a/src/components/InputTime/InputTime.test.tsx
+++ b/src/components/InputTime/InputTime.test.tsx
@@ -529,4 +529,80 @@ describe('InputTime', { timeout: 10000 }, () => {
     );
     expect(getInput().value).toBe('1:00:00');
   });
+
+  describe('Append Button', () => {
+    it('renders append button when icon and handler are provided', () => {
+      const handleAppendClick = vi.fn();
+      const icon = <span>ICON</span>;
+      render(
+        <InputTime
+          {...defaultProps}
+          appendButtonIcon={icon}
+          onAppendButtonClick={handleAppendClick}
+          appendButtonLabel="Test Append"
+        />
+      );
+      const appendButton = screen.getByLabelText('Test Append');
+      expect(appendButton).toBeDefined();
+      expect(appendButton.textContent).toBe('ICON');
+    });
+
+    it('does not render append button if icon is missing', () => {
+      const handleAppendClick = vi.fn();
+      render(
+        <InputTime
+          {...defaultProps}
+          onAppendButtonClick={handleAppendClick}
+          appendButtonLabel="Test Append No Icon"
+        />
+      );
+      expect(screen.queryByLabelText('Test Append No Icon')).toBeNull();
+    });
+
+    it('does not render append button if handler is missing', () => {
+      const icon = <span>ICON</span>;
+      render(
+        <InputTime
+          {...defaultProps}
+          appendButtonIcon={icon}
+          appendButtonLabel="Test Append No Handler"
+        />
+      );
+      expect(screen.queryByLabelText('Test Append No Handler')).toBeNull();
+    });
+
+    it('calls onAppendButtonClick when append button is clicked', async () => {
+      const handleAppendClick = vi.fn();
+      const icon = <span>ICON</span>;
+      render(
+        <InputTime
+          {...defaultProps}
+          appendButtonIcon={icon}
+          onAppendButtonClick={handleAppendClick}
+          appendButtonLabel="Clickable Append"
+        />
+      );
+      const appendButton = screen.getByLabelText('Clickable Append');
+      await user.click(appendButton);
+      expect(handleAppendClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('append button is disabled when InputTime is disabled', () => {
+      const handleAppendClick = vi.fn();
+      const icon = <span>ICON</span>;
+      render(
+        <InputTime
+          {...defaultProps}
+          appendButtonIcon={icon}
+          onAppendButtonClick={handleAppendClick}
+          appendButtonLabel="Disabled Append"
+          disabled={true}
+        />
+      );
+      const appendButton = screen.getByLabelText(
+        'Disabled Append'
+      ) as HTMLButtonElement;
+      expect(appendButton.disabled).toBe(true);
+    });
+  });
 });

--- a/src/components/InputTime/InputTime.tsx
+++ b/src/components/InputTime/InputTime.tsx
@@ -150,6 +150,9 @@ interface InputTimeProps {
   className?: string;
   inputClassName?: string;
   buttonClassName?: string;
+  onAppendButtonClick?: () => void;
+  appendButtonIcon?: React.ReactNode;
+  appendButtonLabel?: string;
 }
 
 // --- The Component (logic mostly same, relies on new secondsToHMSs) ---
@@ -166,6 +169,9 @@ export const InputTime: React.FC<InputTimeProps> = ({
   className = '',
   inputClassName = '',
   buttonClassName: _buttonClassName = '',
+  onAppendButtonClick,
+  appendButtonIcon,
+  appendButtonLabel = 'Append button',
   ...restProps
 }) => {
   const decimalPlaces = getStepDecimalPlaces(step);
@@ -293,8 +299,26 @@ export const InputTime: React.FC<InputTimeProps> = ({
     }
   };
 
-  const append = (
-    <div className={css.stepper}>
+  const appendElements: React.ReactNode[] = [];
+
+  if (onAppendButtonClick && appendButtonIcon) {
+    appendElements.push(
+      <Button
+        key="append-button"
+        size="x-small"
+        variant="ghost"
+        padding="none"
+        onClick={onAppendButtonClick}
+        disabled={disabled}
+        aria-label={appendButtonLabel}
+        className={css.appendButton}>
+        {appendButtonIcon}
+      </Button>
+    );
+  }
+
+  appendElements.push(
+    <div className={css.stepper} key="stepper">
       <Button
         size="x-small"
         variant="ghost"
@@ -315,6 +339,8 @@ export const InputTime: React.FC<InputTimeProps> = ({
       </Button>
     </div>
   );
+
+  const append = <div className={css.appendContainer}>{appendElements}</div>;
 
   return (
     <div className={`time-input-container ${className}`}>


### PR DESCRIPTION
- Adds buttons to Start and Duration inputs in the ConfigurationPanel.
- Start input button sets start time to video's current time.
- Duration input button sets duration to time between start and video's current time.
- Includes tests for new component functionalities and ConfigurationPanel logic.