### PR TITLE
Refactor ConfigurationPanel to use Zustand store

### DIFF
--- a/src/components/ButtonToggle/ButtonToggle.tsx
+++ b/src/components/ButtonToggle/ButtonToggle.tsx
@@ -32,6 +32,7 @@ export function ButtonToggle({
         type="checkbox"
         checked={checked}
         onChange={(e) => onChange(e.target.checked)}
+        aria-label={name} // Use the name prop as the aria-label
       />
     </Button>
   );

--- a/src/components/ConfigurationPanel/ConfigurationPanel.tsx
+++ b/src/components/ConfigurationPanel/ConfigurationPanel.tsx
@@ -80,26 +80,6 @@ function ConfigurationPanel({ onSubmit }: ConfigurationPanelProps) {
     };
   }, [video, handleVideoLoadedData]);
 
-  // The 'seeked' event listener in the original component was dispatching an action
-  // but that action didn't modify state. If such observation is needed,
-  // it can be added here or within the store. For now, it's omitted as it had no state effect.
-  // useEffect(() => {
-  //   if (!(video instanceof HTMLVideoElement)) {
-  //     return;
-  //   }
-  //   function handleVideoSeekedCallback() {
-  //     const { isOpen, status } = useAppStore.getState();
-  //     if (video && isOpen && status === 'configuring' && video.paused) {
-  //       // Assuming handleVideoSeeked exists in the store and you want to call it
-  //       // useConfigurationPanelStore.getState().handleVideoSeeked({ currentTime: video.currentTime });
-  //     }
-  //   }
-  //   video.addEventListener('seeked', handleVideoSeekedCallback);
-  //   return () => {
-  //     video.removeEventListener('seeked', handleVideoSeekedCallback);
-  //   };
-  // }, [video]);
-
   if (!video) {
     return null; // Or some placeholder/loading UI
   }

--- a/src/components/ConfigurationPanel/ConfigurationPanel.tsx
+++ b/src/components/ConfigurationPanel/ConfigurationPanel.tsx
@@ -1,10 +1,11 @@
 import css from './ConfigurationPanel.module.css';
+import { useEffect } from 'react';
 
-import { useEffect, useReducer } from 'react';
-
-import { clamp } from '@/utils/clamp.js';
 import { useAppStore } from '@/stores/appStore';
-import { log } from '@/utils/logger';
+import {
+  useConfigurationPanelStore,
+  type ConfigState
+} from '@/stores/configurationPanelStore';
 
 import { Input } from '../Input/Input';
 import { InputNumber } from '../InputNumber/InputNumber';
@@ -15,193 +16,112 @@ import { ButtonToggle } from '../ButtonToggle/ButtonToggle';
 import LinkIcon from '@/assets/link.svg?react';
 import LinkEmptyIcon from '@/assets/link-empty.svg?react';
 
-const DEFAULT_WIDTH = 320;
-const DEFAULT_HEIGHT = 180;
-
-interface ConfigState {
-  start: number;
-  duration: number;
-  width: number;
-  height: number;
-  linkDimensions: boolean;
-  framerate: number;
-  quality: number;
-  aspectRatio: number;
-}
-
-// This creates a union of all possible input change payloads, e.g.,
-// { name: 'start'; value: number } | { name: 'linkDimensions'; value: boolean }
-type InputActionPayload = {
-  [K in keyof ConfigState]: { name: K; value: ConfigState[K] };
-}[keyof ConfigState];
-
-// FIX: Created a discriminated union for all possible actions for type safety in the reducer.
-type ConfigAction =
-  | { type: 'INPUT_CHANGE'; payload: InputActionPayload }
-  | { type: 'VIDEO_LOADED_DATA'; payload: { aspectRatio: number } }
-  | { type: 'VIDEO_SEEKED'; payload: { currentTime: number } }
-  | { type: 'SET_START_TO_CURRENT_TIME'; payload: { currentTime: number } };
-
-function seekTo(videoElement: HTMLVideoElement, time: number) {
-  if (typeof time !== 'number' || time < 0) {
-    log(`Could not seek to ${time}`);
-    return;
-  }
-
-  videoElement.currentTime = clamp(0, videoElement.duration, time);
-  videoElement.pause(); // ensure video does not play on its own
-}
-
-function getVideoAspectRatio(videoElement: HTMLVideoElement) {
-  return videoElement.videoWidth / videoElement.videoHeight;
-}
-
-// FIX: Added explicit return type annotation for the reducer.
-function reducer(state: ConfigState, action: ConfigAction): ConfigState {
-  switch (action.type) {
-    case 'INPUT_CHANGE': {
-      // Because of the improved ConfigAction type, TypeScript now knows that
-      // action.payload.name and action.payload.value are correctly linked.
-      const { name, value } = action.payload;
-
-      const newState = {
-        ...state,
-        [name]: value
-      };
-
-      // adjust other dimension if they are linked
-      if (state.linkDimensions) {
-        // The payload is a discriminated union, so we check the 'name' property
-        if (action.payload.name === 'width') {
-          // TS now knows action.payload.value is a number
-          newState.height = Math.round(
-            action.payload.value / state.aspectRatio
-          );
-        } else if (action.payload.name === 'height') {
-          // TS now knows action.payload.value is a number
-          newState.width = Math.round(action.payload.value * state.aspectRatio);
-        }
-      }
-
-      // adjust height if linkDimensions is turned on
-      if (action.payload.name === 'linkDimensions' && action.payload.value) {
-        newState.height = Math.round(state.width / state.aspectRatio);
-      }
-
-      return newState;
-    }
-
-    case 'VIDEO_LOADED_DATA': {
-      return {
-        ...state,
-        aspectRatio: action.payload.aspectRatio,
-        height: Math.round(state.width / action.payload.aspectRatio)
-      };
-    }
-
-    case 'SET_START_TO_CURRENT_TIME': {
-      return {
-        ...state,
-        start: action.payload.currentTime
-      };
-    }
-
-    case 'VIDEO_SEEKED':
-    default:
-      // FIX: No need to spread state here, just return it.
-      return state;
-  }
-}
-
 interface ConfigurationPanelProps {
-  // FIX: Changed 'Function' to a specific signature for type safety.
   onSubmit: (config: ConfigState) => void;
 }
 
 function ConfigurationPanel({ onSubmit }: ConfigurationPanelProps) {
   const video = useAppStore((state) => state.videoElement);
+  const {
+    start,
+    duration,
+    width,
+    height,
+    linkDimensions,
+    framerate,
+    quality,
+    videoDuration,
+    videoWidth: configVideoWidth, // Renamed to avoid conflict with component's width
+    videoHeight: configVideoHeight, // Renamed to avoid conflict with component's height
+    handleInputChange: storeHandleInputChange,
+    handleVideoLoadedData,
+    // handleVideoSeeked, // Not directly used for state change in component
+    handleSetStartToCurrentTime,
+    seekVideo,
+    resetState
+  } = useConfigurationPanelStore();
 
-  const [state, dispatch] = useReducer(reducer, {
-    start: video?.currentTime ?? 0,
-    duration: 2,
-    width: DEFAULT_WIDTH,
-    height: DEFAULT_HEIGHT,
-    linkDimensions: true,
-    framerate: 10,
-    quality: 5,
-    aspectRatio: DEFAULT_WIDTH / DEFAULT_HEIGHT
-  });
+  useEffect(() => {
+    // Reset store state when component mounts or video element changes significantly
+    // This is now primarily handled by the store's subscription to appStore.
+    // However, an initial reset on mount might still be desired if the video element
+    // is already present when the component mounts.
+    if (video) {
+      resetState(video);
+    }
+  }, [video, resetState]);
 
   useEffect(() => {
     if (!(video instanceof HTMLVideoElement)) {
       return;
     }
 
-    function handleLoadedMetadata() {
-      const aspectRatio = getVideoAspectRatio(video as HTMLVideoElement);
-      dispatch({
-        type: 'VIDEO_LOADED_DATA',
-        payload: {
-          aspectRatio
-        }
-      });
-    }
-
-    handleLoadedMetadata();
-    video.addEventListener('loadedmetadata', handleLoadedMetadata);
-
-    return () => {
-      video.removeEventListener('loadedmetadata', handleLoadedMetadata);
-    };
-  }, [video]);
-
-  useEffect(() => {
-    if (!(video instanceof HTMLVideoElement)) {
-      return;
-    }
-
-    function handleVideoSeeked() {
-      const { isOpen, status } = useAppStore.getState();
-      if (video && isOpen && status === 'configuring' && video.paused) {
-        dispatch({
-          type: 'VIDEO_SEEKED',
-          payload: {
-            currentTime: video.currentTime
-          }
+    function handleLoadedMetadataCallback() {
+      if (video) {
+        // Ensure video is still valid
+        handleVideoLoadedData({
+          aspectRatio: video.videoWidth / video.videoHeight,
+          duration: video.duration,
+          videoWidth: video.videoWidth,
+          videoHeight: video.videoHeight
         });
       }
     }
 
-    video.addEventListener('seeked', handleVideoSeeked);
+    // Initial call in case metadata is already loaded
+    if (video.readyState >= 1) {
+      // HAVE_METADATA or higher
+      handleLoadedMetadataCallback();
+    }
+    video.addEventListener('loadedmetadata', handleLoadedMetadataCallback);
 
     return () => {
-      video.removeEventListener('seeked', handleVideoSeeked);
+      video.removeEventListener('loadedmetadata', handleLoadedMetadataCallback);
     };
-  }, [video]);
+  }, [video, handleVideoLoadedData]);
+
+  // The 'seeked' event listener in the original component was dispatching an action
+  // but that action didn't modify state. If such observation is needed,
+  // it can be added here or within the store. For now, it's omitted as it had no state effect.
+  // useEffect(() => {
+  //   if (!(video instanceof HTMLVideoElement)) {
+  //     return;
+  //   }
+  //   function handleVideoSeekedCallback() {
+  //     const { isOpen, status } = useAppStore.getState();
+  //     if (video && isOpen && status === 'configuring' && video.paused) {
+  //       // Assuming handleVideoSeeked exists in the store and you want to call it
+  //       // useConfigurationPanelStore.getState().handleVideoSeeked({ currentTime: video.currentTime });
+  //     }
+  //   }
+  //   video.addEventListener('seeked', handleVideoSeekedCallback);
+  //   return () => {
+  //     video.removeEventListener('seeked', handleVideoSeekedCallback);
+  //   };
+  // }, [video]);
 
   if (!video) {
-    return;
+    return null; // Or some placeholder/loading UI
   }
 
-  const maxWidth = Math.min(video.videoWidth, 1920);
-  const maxHeight = Math.max(video.videoHeight, 1080);
-  const maxStart = video.duration - state.duration;
-  const maxDuration = Math.min(video.duration - state.start, 30);
+  const maxWidth = Math.min(configVideoWidth || video.videoWidth, 1920);
+  const maxHeight = Math.min(configVideoHeight || video.videoHeight, 1080); // Corrected to Math.min
+  const maxStart = Math.max(0, videoDuration - duration); // Ensure maxStart is not negative
+  const maxDuration = Math.min(videoDuration - start, 30);
 
-  // FIX: Changed event type from 'InputEvent' to React's 'ChangeEvent'.
-  function handleInputChange(event: React.ChangeEvent<HTMLInputElement>) {
+  function handleGenericInputChange(
+    event: React.ChangeEvent<HTMLInputElement>
+  ) {
     const inputElement = event.target;
-    const fieldName = inputElement.name;
+    const fieldName = inputElement.name as keyof ConfigState; // Type assertion
 
-    // FIX: Input values are always strings. They must be parsed to numbers.
     const numericValue = parseFloat(inputElement.value);
-
-    // Prevent dispatching NaN if the input is cleared or invalid.
-    if (isNaN(numericValue)) {
+    if (isNaN(numericValue) && fieldName !== 'linkDimensions') {
+      // linkDimensions is boolean
       return;
     }
 
-    // This check helps TypeScript narrow the type of 'fieldName'
+    // Narrow down the type for storeHandleInputChange
     if (
       fieldName === 'duration' ||
       fieldName === 'width' ||
@@ -209,64 +129,59 @@ function ConfigurationPanel({ onSubmit }: ConfigurationPanelProps) {
       fieldName === 'framerate' ||
       fieldName === 'quality'
     ) {
-      dispatch({
-        type: 'INPUT_CHANGE',
-        payload: {
-          name: fieldName,
-          value: numericValue
-        }
+      storeHandleInputChange({
+        name: fieldName,
+        value: numericValue
       });
     }
 
-    if (fieldName === 'duration' && video) {
-      const end = state.start + numericValue;
-      seekTo(video, end);
+    if (fieldName === 'duration') {
+      const end = start + numericValue;
+      seekVideo(end);
     }
   }
 
-  function handleStartChange(newStart: number) {
-    dispatch({
-      type: 'INPUT_CHANGE',
-      payload: {
-        name: 'start',
-        value: newStart
-      }
+  function handleStartTimeChange(newStart: number) {
+    storeHandleInputChange({
+      name: 'start',
+      value: newStart
     });
-
-    if (video) {
-      seekTo(video, newStart);
-    }
+    seekVideo(newStart);
   }
 
-  function handleLinkChange(isLinked: boolean) {
-    dispatch({
-      type: 'INPUT_CHANGE',
-      payload: {
-        name: 'linkDimensions',
-        value: isLinked
-      }
+  function handleLinkToggleChange(isLinked: boolean) {
+    storeHandleInputChange({
+      name: 'linkDimensions',
+      value: isLinked
     });
   }
 
-  // FIX: Changed event type from 'SubmitEvent' to React's 'FormEvent'.
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    onSubmit(state);
+    // Construct config object from store state to pass to onSubmit
+    const currentConfigState = useConfigurationPanelStore.getState();
+    onSubmit({
+      start,
+      duration,
+      width,
+      height,
+      linkDimensions,
+      framerate,
+      quality,
+      aspectRatio: currentConfigState.aspectRatio, // Ensure this is the calculated one
+      videoDuration: currentConfigState.videoDuration,
+      videoWidth: currentConfigState.videoWidth,
+      videoHeight: currentConfigState.videoHeight
+    });
   }
 
-  // FIX: Changed event type from 'KeyboardEvent' to React's 'KeyboardEvent'.
   function handleKeyDown(event: React.KeyboardEvent<HTMLFormElement>) {
     event.stopPropagation();
   }
 
   function handleSetStartToCurrentTimeClick() {
     if (video) {
-      dispatch({
-        type: 'SET_START_TO_CURRENT_TIME',
-        payload: {
-          currentTime: video.currentTime
-        }
-      });
+      handleSetStartToCurrentTime({ currentTime: video.currentTime });
     }
   }
 
@@ -280,10 +195,10 @@ function ConfigurationPanel({ onSubmit }: ConfigurationPanelProps) {
           className={css.start}
           name="start"
           label="Start"
-          value={state.start}
+          value={start}
           min={0}
           max={maxStart}
-          onChange={handleStartChange}
+          onChange={handleStartTimeChange}
           append={
             <Button
               title="Set to current time"
@@ -300,21 +215,21 @@ function ConfigurationPanel({ onSubmit }: ConfigurationPanelProps) {
           name="duration"
           label="Duration"
           type="number"
-          value={String(state.duration)}
-          min={1 / state.framerate}
+          value={String(duration)}
+          min={1 / framerate}
           max={maxDuration}
-          step={1 / state.framerate}
-          onChange={handleInputChange}
+          step={1 / framerate}
+          onChange={handleGenericInputChange}
         />
         <InputNumber
           className={css.width}
           name="width"
           label="Width"
           type="number"
-          value={String(state.width)}
+          value={String(width)}
           min={32}
           max={maxWidth}
-          onChange={handleInputChange}
+          onChange={handleGenericInputChange}
         />
         <ButtonToggle
           className={css.linkDimensions}
@@ -324,9 +239,9 @@ function ConfigurationPanel({ onSubmit }: ConfigurationPanelProps) {
           variant="input"
           padding="small"
           evenPadding={true}
-          checked={state.linkDimensions}
-          onChange={handleLinkChange}>
-          {state.linkDimensions ? (
+          checked={linkDimensions}
+          onChange={handleLinkToggleChange}>
+          {linkDimensions ? (
             <LinkIcon className={css.linkIcon} />
           ) : (
             <LinkEmptyIcon className={css.linkIcon} />
@@ -337,10 +252,10 @@ function ConfigurationPanel({ onSubmit }: ConfigurationPanelProps) {
           name="height"
           label="Height"
           type="number"
-          value={String(state.height)}
+          value={String(height)}
           min={32}
           max={maxHeight}
-          onChange={handleInputChange}
+          onChange={handleGenericInputChange}
         />
         <InputNumber
           className={css.fps}
@@ -349,8 +264,8 @@ function ConfigurationPanel({ onSubmit }: ConfigurationPanelProps) {
           type="number"
           min={1}
           max={60}
-          value={String(state.framerate)}
-          onChange={handleInputChange}
+          value={String(framerate)}
+          onChange={handleGenericInputChange}
         />
         <Input
           className={css.quality}
@@ -359,8 +274,8 @@ function ConfigurationPanel({ onSubmit }: ConfigurationPanelProps) {
           type="range"
           min={1}
           max={10}
-          value={String(state.quality)}
-          onChange={handleInputChange}
+          value={String(quality)}
+          onChange={handleGenericInputChange}
         />
         <Button id="gifit-submit" className={css.submit} type="submit">
           GIFit!

--- a/src/components/InputNumber/InputNumber.tsx
+++ b/src/components/InputNumber/InputNumber.tsx
@@ -80,7 +80,8 @@ export function InputNumber({
           padding="none"
           onPointerDown={handleUpPressStart}
           onPointerUp={handleUpPressEnd}
-          disabled={restProps.disabled}>
+          disabled={restProps.disabled}
+          aria-label="Increment">
           ▲
         </Button>
         <Button
@@ -89,7 +90,8 @@ export function InputNumber({
           padding="none"
           onPointerDown={handleDownPressStart}
           onPointerUp={handleDownPressEnd}
-          disabled={restProps.disabled}>
+          disabled={restProps.disabled}
+          aria-label="Decrement">
           ▼
         </Button>
       </div>

--- a/src/stores/configurationPanelStore.test.ts
+++ b/src/stores/configurationPanelStore.test.ts
@@ -1,0 +1,261 @@
+import { act, renderHook } from '@testing-library/react';
+import { useConfigurationPanelStore } from './configurationPanelStore';
+import { useAppStore } from './appStore';
+
+// Mock HTMLVideoElement
+const mockVideoElement = {
+  currentTime: 0,
+  duration: 10,
+  videoWidth: 640,
+  videoHeight: 360,
+  readyState: 1, // HAVE_METADATA
+  pause: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn()
+} as unknown as HTMLVideoElement;
+
+const mockVideoElement2 = {
+  currentTime: 5,
+  duration: 20,
+  videoWidth: 1280,
+  videoHeight: 720,
+  readyState: 1, // HAVE_METADATA
+  pause: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn()
+} as unknown as HTMLVideoElement;
+
+describe('useConfigurationPanelStore', () => {
+  beforeEach(() => {
+    // Resetting stores before each test
+    act(() => {
+      useAppStore.getState().reset();
+      // Pass undefined to resetState to use the default initial state logic
+      useConfigurationPanelStore.getState().resetState(undefined);
+    });
+    // Set a default video element in appStore for consistent testing environment
+    act(() => {
+      useAppStore.getState().setVideoElement(mockVideoElement);
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should initialize with default state based on mockVideoElement', () => {
+    const { result } = renderHook(() => useConfigurationPanelStore());
+    expect(result.current.start).toBe(0);
+    expect(result.current.duration).toBe(2);
+    expect(result.current.width).toBe(640); // from mockVideoElement
+    expect(result.current.height).toBe(360); // from mockVideoElement
+    expect(result.current.linkDimensions).toBe(true);
+    expect(result.current.framerate).toBe(10);
+    expect(result.current.quality).toBe(5);
+    expect(result.current.aspectRatio).toBe(640 / 360);
+    expect(result.current.videoDuration).toBe(10);
+  });
+
+  it('handleInputChange should update state correctly', () => {
+    const { result } = renderHook(() => useConfigurationPanelStore());
+
+    act(() => {
+      result.current.handleInputChange({ name: 'width', value: 800 });
+    });
+    expect(result.current.width).toBe(800);
+    // Height should also change because linkDimensions is true and aspectRatio is 640/360
+    expect(result.current.height).toBe(Math.round(800 / (640 / 360)));
+
+    act(() => {
+      result.current.handleInputChange({
+        name: 'linkDimensions',
+        value: false
+      });
+    });
+    expect(result.current.linkDimensions).toBe(false);
+
+    act(() => {
+      result.current.handleInputChange({ name: 'height', value: 400 });
+    });
+    // Width should not change now
+    expect(result.current.width).toBe(800);
+    expect(result.current.height).toBe(400);
+
+    act(() => {
+      result.current.handleInputChange({ name: 'linkDimensions', value: true });
+    });
+    // When linkDimensions is turned back on, height should adjust to width based on current aspect ratio
+    expect(result.current.height).toBe(
+      Math.round(result.current.width / result.current.aspectRatio)
+    );
+
+    act(() => {
+      result.current.handleInputChange({ name: 'framerate', value: 24 });
+    });
+    expect(result.current.framerate).toBe(24);
+  });
+
+  it('handleVideoLoadedData should update video-related state', () => {
+    const { result } = renderHook(() => useConfigurationPanelStore());
+    const newVideoData = {
+      aspectRatio: 16 / 9,
+      duration: 15,
+      videoWidth: 1920,
+      videoHeight: 1080
+    };
+
+    act(() => {
+      result.current.handleVideoLoadedData(newVideoData);
+    });
+
+    expect(result.current.aspectRatio).toBe(16 / 9);
+    expect(result.current.videoDuration).toBe(15);
+    expect(result.current.videoWidth).toBe(1920);
+    expect(result.current.videoHeight).toBe(1080);
+    // Height should adjust if linked or was default
+    expect(result.current.height).toBe(
+      Math.round(result.current.width / (16 / 9))
+    );
+  });
+
+  it('handleSetStartToCurrentTime should update start time', () => {
+    const { result } = renderHook(() => useConfigurationPanelStore());
+    act(() => {
+      result.current.handleSetStartToCurrentTime({ currentTime: 3.5 });
+    });
+    expect(result.current.start).toBe(3.5);
+  });
+
+  it('seekVideo should call videoElement.currentTime and pause', () => {
+    const { result } = renderHook(() => useConfigurationPanelStore());
+    act(() => {
+      result.current.seekVideo(5);
+    });
+    expect(mockVideoElement.currentTime).toBe(5);
+    expect(mockVideoElement.pause).toHaveBeenCalled();
+  });
+
+  it('resetState should reset to initial state based on current videoElement', () => {
+    const { result } = renderHook(() => useConfigurationPanelStore());
+    // Change some state
+    act(() => {
+      result.current.handleInputChange({ name: 'width', value: 1000 });
+      result.current.handleInputChange({ name: 'duration', value: 5 });
+    });
+    expect(result.current.width).toBe(1000);
+    expect(result.current.duration).toBe(5);
+
+    // Reset state
+    act(() => {
+      result.current.resetState(mockVideoElement); // Explicitly pass for clarity, though it would pick from appStore
+    });
+
+    // Check if state is reset to initial values based on mockVideoElement
+    expect(result.current.start).toBe(mockVideoElement.currentTime);
+    expect(result.current.duration).toBe(2); // Default duration
+    expect(result.current.width).toBe(mockVideoElement.videoWidth);
+    expect(result.current.height).toBe(mockVideoElement.videoHeight);
+    expect(result.current.aspectRatio).toBe(
+      mockVideoElement.videoWidth / mockVideoElement.videoHeight
+    );
+  });
+
+  it('should react to videoElement changes in appStore', () => {
+    const { result } = renderHook(() => useConfigurationPanelStore());
+
+    // Initial state based on mockVideoElement
+    expect(result.current.videoWidth).toBe(mockVideoElement.videoWidth);
+    expect(result.current.videoHeight).toBe(mockVideoElement.videoHeight);
+    expect(result.current.videoDuration).toBe(mockVideoElement.duration);
+
+    // Change videoElement in appStore
+    act(() => {
+      useAppStore.getState().setVideoElement(mockVideoElement2);
+    });
+
+    // Wait for subscribers to be notified and state to update
+    // Zustand updates are synchronous, but renderHook might need a tick
+    // Forcing a re-render or checking after a timeout might be more robust in complex scenarios
+    // but here, direct check should work due to direct subscription model.
+    // However, renderHook's result doesn't auto-update on external store changes directly.
+    // We need to get the latest state from the store itself, or re-render the hook.
+
+    const newState = useConfigurationPanelStore.getState();
+    expect(newState.videoWidth).toBe(mockVideoElement2.videoWidth);
+    expect(newState.videoHeight).toBe(mockVideoElement2.videoHeight);
+    expect(newState.videoDuration).toBe(mockVideoElement2.duration);
+    expect(newState.start).toBe(mockVideoElement2.currentTime);
+    expect(newState.width).toBe(mockVideoElement2.videoWidth); // Width should update
+    expect(newState.height).toBe(mockVideoElement2.videoHeight); // Height should update
+    expect(newState.aspectRatio).toBe(
+      mockVideoElement2.videoWidth / mockVideoElement2.videoHeight
+    );
+  });
+
+  it('handleInputChange should correctly toggle linkDimensions and adjust dimensions', () => {
+    const { result } = renderHook(() => useConfigurationPanelStore());
+    const initialWidth = result.current.width;
+    const initialHeight = result.current.height;
+    const initialAspectRatio = result.current.aspectRatio;
+
+    // Turn off linkDimensions
+    act(() => {
+      result.current.handleInputChange({
+        name: 'linkDimensions',
+        value: false
+      });
+    });
+    expect(result.current.linkDimensions).toBe(false);
+
+    // Change width, height should not change
+    act(() => {
+      result.current.handleInputChange({
+        name: 'width',
+        value: initialWidth + 100
+      });
+    });
+    expect(result.current.width).toBe(initialWidth + 100);
+    expect(result.current.height).toBe(initialHeight); // Height remains unchanged
+
+    // Turn on linkDimensions
+    act(() => {
+      result.current.handleInputChange({ name: 'linkDimensions', value: true });
+    });
+    expect(result.current.linkDimensions).toBe(true);
+    // Height should now adjust to the new width, based on the original aspect ratio
+    expect(result.current.height).toBe(
+      Math.round((initialWidth + 100) / initialAspectRatio)
+    );
+  });
+
+  it('should handle video element being null initially then set', () => {
+    // Reset appStore to have no video element initially
+    act(() => {
+      useAppStore.getState().reset();
+      useAppStore.getState().setVideoElement(null as any); // Explicitly set to null
+      // Reset config store, it should use default values as videoElement is null
+      useConfigurationPanelStore.getState().resetState(undefined);
+    });
+
+    const { result: configStoreHook } = renderHook(() =>
+      useConfigurationPanelStore()
+    );
+
+    // Check for default initial state when no video
+    expect(configStoreHook.current.width).toBe(320); // DEFAULT_WIDTH
+    expect(configStoreHook.current.height).toBe(180); // DEFAULT_HEIGHT
+    expect(configStoreHook.current.videoDuration).toBe(0);
+
+    // Now set a video element in appStore
+    act(() => {
+      useAppStore.getState().setVideoElement(mockVideoElement);
+    });
+
+    // State should update based on the new video element
+    const updatedState = useConfigurationPanelStore.getState();
+    expect(updatedState.width).toBe(mockVideoElement.videoWidth);
+    expect(updatedState.height).toBe(mockVideoElement.videoHeight);
+    expect(updatedState.videoDuration).toBe(mockVideoElement.duration);
+    expect(updatedState.start).toBe(mockVideoElement.currentTime);
+  });
+});

--- a/src/stores/configurationPanelStore.test.ts
+++ b/src/stores/configurationPanelStore.test.ts
@@ -242,9 +242,10 @@ describe('useConfigurationPanelStore', () => {
     );
 
     // Check for default initial state when no video
-    expect(configStoreHook.current.width).toBe(320); // DEFAULT_WIDTH
-    expect(configStoreHook.current.height).toBe(180); // DEFAULT_HEIGHT
+    expect(configStoreHook.current.width).toBe(420); // Updated DEFAULT_WIDTH
+    expect(configStoreHook.current.height).toBe(Math.round(420 / (16 / 9))); // Calculated with 16:9 default
     expect(configStoreHook.current.videoDuration).toBe(0);
+    expect(configStoreHook.current.aspectRatio).toBe(16 / 9);
 
     // Now set a video element in appStore
     act(() => {

--- a/src/stores/configurationPanelStore.test.ts
+++ b/src/stores/configurationPanelStore.test.ts
@@ -27,13 +27,10 @@ const mockVideoElement2 = {
 
 describe('useConfigurationPanelStore', () => {
   beforeEach(() => {
-    // Resetting stores before each test
     act(() => {
       useAppStore.getState().reset();
-      // Pass undefined to resetState to use the default initial state logic
       useConfigurationPanelStore.getState().resetState(undefined);
     });
-    // Set a default video element in appStore for consistent testing environment
     act(() => {
       useAppStore.getState().setVideoElement(mockVideoElement);
     });
@@ -43,29 +40,38 @@ describe('useConfigurationPanelStore', () => {
     vi.clearAllMocks();
   });
 
-  it('should initialize with default state based on mockVideoElement', () => {
+  it('should initialize with default state based on mockVideoElement (width capped)', () => {
     const { result } = renderHook(() => useConfigurationPanelStore());
     expect(result.current.start).toBe(0);
     expect(result.current.duration).toBe(2);
-    expect(result.current.width).toBe(640); // from mockVideoElement
-    expect(result.current.height).toBe(360); // from mockVideoElement
+    expect(result.current.width).toBe(420);
+    expect(result.current.height).toBe(
+      Math.round(
+        420 / (mockVideoElement.videoWidth / mockVideoElement.videoHeight)
+      )
+    );
     expect(result.current.linkDimensions).toBe(true);
     expect(result.current.framerate).toBe(10);
     expect(result.current.quality).toBe(5);
-    expect(result.current.aspectRatio).toBe(640 / 360);
+    expect(result.current.aspectRatio).toBe(
+      mockVideoElement.videoWidth / mockVideoElement.videoHeight
+    );
     expect(result.current.videoDuration).toBe(10);
+    expect(result.current.videoWidth).toBe(640);
+    expect(result.current.videoHeight).toBe(360);
   });
 
   it('handleInputChange should update state correctly', () => {
     const { result } = renderHook(() => useConfigurationPanelStore());
-
     act(() => {
       result.current.handleInputChange({ name: 'width', value: 800 });
     });
     expect(result.current.width).toBe(800);
-    // Height should also change because linkDimensions is true and aspectRatio is 640/360
-    expect(result.current.height).toBe(Math.round(800 / (640 / 360)));
-
+    expect(result.current.height).toBe(
+      Math.round(
+        800 / (mockVideoElement.videoWidth / mockVideoElement.videoHeight)
+      )
+    );
     act(() => {
       result.current.handleInputChange({
         name: 'linkDimensions',
@@ -73,22 +79,17 @@ describe('useConfigurationPanelStore', () => {
       });
     });
     expect(result.current.linkDimensions).toBe(false);
-
     act(() => {
       result.current.handleInputChange({ name: 'height', value: 400 });
     });
-    // Width should not change now
     expect(result.current.width).toBe(800);
     expect(result.current.height).toBe(400);
-
     act(() => {
       result.current.handleInputChange({ name: 'linkDimensions', value: true });
     });
-    // When linkDimensions is turned back on, height should adjust to width based on current aspect ratio
     expect(result.current.height).toBe(
       Math.round(result.current.width / result.current.aspectRatio)
     );
-
     act(() => {
       result.current.handleInputChange({ name: 'framerate', value: 24 });
     });
@@ -97,24 +98,23 @@ describe('useConfigurationPanelStore', () => {
 
   it('handleVideoLoadedData should update video-related state', () => {
     const { result } = renderHook(() => useConfigurationPanelStore());
+    const currentWidthBeforeLoad = result.current.width; // Should be 420 (capped from mockVideoElement)
     const newVideoData = {
-      aspectRatio: 16 / 9,
+      aspectRatio: 1920 / 1080, // 16/9
       duration: 15,
       videoWidth: 1920,
       videoHeight: 1080
     };
-
     act(() => {
       result.current.handleVideoLoadedData(newVideoData);
     });
-
-    expect(result.current.aspectRatio).toBe(16 / 9);
+    expect(result.current.aspectRatio).toBe(1920 / 1080);
     expect(result.current.videoDuration).toBe(15);
     expect(result.current.videoWidth).toBe(1920);
     expect(result.current.videoHeight).toBe(1080);
-    // Height should adjust if linked or was default
+    // Height should adjust based on current display width and NEW video aspect ratio if linked
     expect(result.current.height).toBe(
-      Math.round(result.current.width / (16 / 9))
+      Math.round(currentWidthBeforeLoad / (1920 / 1080))
     );
   });
 
@@ -137,24 +137,23 @@ describe('useConfigurationPanelStore', () => {
 
   it('resetState should reset to initial state based on current videoElement', () => {
     const { result } = renderHook(() => useConfigurationPanelStore());
-    // Change some state
     act(() => {
       result.current.handleInputChange({ name: 'width', value: 1000 });
       result.current.handleInputChange({ name: 'duration', value: 5 });
     });
     expect(result.current.width).toBe(1000);
     expect(result.current.duration).toBe(5);
-
-    // Reset state
     act(() => {
-      result.current.resetState(mockVideoElement); // Explicitly pass for clarity, though it would pick from appStore
+      result.current.resetState(mockVideoElement);
     });
-
-    // Check if state is reset to initial values based on mockVideoElement
     expect(result.current.start).toBe(mockVideoElement.currentTime);
-    expect(result.current.duration).toBe(2); // Default duration
-    expect(result.current.width).toBe(mockVideoElement.videoWidth);
-    expect(result.current.height).toBe(mockVideoElement.videoHeight);
+    expect(result.current.duration).toBe(2);
+    expect(result.current.width).toBe(420);
+    expect(result.current.height).toBe(
+      Math.round(
+        420 / (mockVideoElement.videoWidth / mockVideoElement.videoHeight)
+      )
+    );
     expect(result.current.aspectRatio).toBe(
       mockVideoElement.videoWidth / mockVideoElement.videoHeight
     );
@@ -162,34 +161,37 @@ describe('useConfigurationPanelStore', () => {
 
   it('should react to videoElement changes in appStore', () => {
     const { result } = renderHook(() => useConfigurationPanelStore());
-
-    // Initial state based on mockVideoElement
+    expect(result.current.width).toBe(420);
+    expect(result.current.height).toBe(
+      Math.round(
+        420 / (mockVideoElement.videoWidth / mockVideoElement.videoHeight)
+      )
+    );
+    expect(result.current.aspectRatio).toBe(
+      mockVideoElement.videoWidth / mockVideoElement.videoHeight
+    );
     expect(result.current.videoWidth).toBe(mockVideoElement.videoWidth);
     expect(result.current.videoHeight).toBe(mockVideoElement.videoHeight);
     expect(result.current.videoDuration).toBe(mockVideoElement.duration);
 
-    // Change videoElement in appStore
     act(() => {
-      useAppStore.getState().setVideoElement(mockVideoElement2);
+      useAppStore.getState().setVideoElement(mockVideoElement2); // 1280x720
     });
 
-    // Wait for subscribers to be notified and state to update
-    // Zustand updates are synchronous, but renderHook might need a tick
-    // Forcing a re-render or checking after a timeout might be more robust in complex scenarios
-    // but here, direct check should work due to direct subscription model.
-    // However, renderHook's result doesn't auto-update on external store changes directly.
-    // We need to get the latest state from the store itself, or re-render the hook.
-
     const newState = useConfigurationPanelStore.getState();
+    expect(newState.width).toBe(420);
+    expect(newState.height).toBe(
+      Math.round(
+        420 / (mockVideoElement2.videoWidth / mockVideoElement2.videoHeight)
+      )
+    );
+    expect(newState.aspectRatio).toBe(
+      mockVideoElement2.videoWidth / mockVideoElement2.videoHeight
+    );
     expect(newState.videoWidth).toBe(mockVideoElement2.videoWidth);
     expect(newState.videoHeight).toBe(mockVideoElement2.videoHeight);
     expect(newState.videoDuration).toBe(mockVideoElement2.duration);
     expect(newState.start).toBe(mockVideoElement2.currentTime);
-    expect(newState.width).toBe(mockVideoElement2.videoWidth); // Width should update
-    expect(newState.height).toBe(mockVideoElement2.videoHeight); // Height should update
-    expect(newState.aspectRatio).toBe(
-      mockVideoElement2.videoWidth / mockVideoElement2.videoHeight
-    );
   });
 
   it('handleInputChange should correctly toggle linkDimensions and adjust dimensions', () => {
@@ -197,8 +199,6 @@ describe('useConfigurationPanelStore', () => {
     const initialWidth = result.current.width;
     const initialHeight = result.current.height;
     const initialAspectRatio = result.current.aspectRatio;
-
-    // Turn off linkDimensions
     act(() => {
       result.current.handleInputChange({
         name: 'linkDimensions',
@@ -206,8 +206,6 @@ describe('useConfigurationPanelStore', () => {
       });
     });
     expect(result.current.linkDimensions).toBe(false);
-
-    // Change width, height should not change
     act(() => {
       result.current.handleInputChange({
         name: 'width',
@@ -215,47 +213,42 @@ describe('useConfigurationPanelStore', () => {
       });
     });
     expect(result.current.width).toBe(initialWidth + 100);
-    expect(result.current.height).toBe(initialHeight); // Height remains unchanged
-
-    // Turn on linkDimensions
+    expect(result.current.height).toBe(initialHeight);
     act(() => {
       result.current.handleInputChange({ name: 'linkDimensions', value: true });
     });
     expect(result.current.linkDimensions).toBe(true);
-    // Height should now adjust to the new width, based on the original aspect ratio
     expect(result.current.height).toBe(
       Math.round((initialWidth + 100) / initialAspectRatio)
     );
   });
 
   it('should handle video element being null initially then set', () => {
-    // Reset appStore to have no video element initially
     act(() => {
       useAppStore.getState().reset();
-      useAppStore.getState().setVideoElement(null as any); // Explicitly set to null
-      // Reset config store, it should use default values as videoElement is null
+      useAppStore.getState().setVideoElement(null as any);
       useConfigurationPanelStore.getState().resetState(undefined);
     });
-
     const { result: configStoreHook } = renderHook(() =>
       useConfigurationPanelStore()
     );
-
-    // Check for default initial state when no video
-    expect(configStoreHook.current.width).toBe(420); // Updated DEFAULT_WIDTH
-    expect(configStoreHook.current.height).toBe(Math.round(420 / (16 / 9))); // Calculated with 16:9 default
+    expect(configStoreHook.current.width).toBe(420);
+    expect(configStoreHook.current.height).toBe(Math.round(420 / (16 / 9)));
     expect(configStoreHook.current.videoDuration).toBe(0);
     expect(configStoreHook.current.aspectRatio).toBe(16 / 9);
-
-    // Now set a video element in appStore
     act(() => {
-      useAppStore.getState().setVideoElement(mockVideoElement);
+      useAppStore.getState().setVideoElement(mockVideoElement); // 640x360
     });
-
-    // State should update based on the new video element
     const updatedState = useConfigurationPanelStore.getState();
-    expect(updatedState.width).toBe(mockVideoElement.videoWidth);
-    expect(updatedState.height).toBe(mockVideoElement.videoHeight);
+    expect(updatedState.width).toBe(420);
+    expect(updatedState.height).toBe(
+      Math.round(
+        420 / (mockVideoElement.videoWidth / mockVideoElement.videoHeight)
+      )
+    );
+    expect(updatedState.aspectRatio).toBe(
+      mockVideoElement.videoWidth / mockVideoElement.videoHeight
+    );
     expect(updatedState.videoDuration).toBe(mockVideoElement.duration);
     expect(updatedState.start).toBe(mockVideoElement.currentTime);
   });

--- a/src/stores/configurationPanelStore.ts
+++ b/src/stores/configurationPanelStore.ts
@@ -99,7 +99,8 @@ const getInitialState = (videoElement?: HTMLVideoElement): ConfigState => {
 };
 
 export const useConfigurationPanelStore = create<ConfigurationPanelStore>(
-  (set, _get) => ({ // Changed get to _get
+  (set, _get) => ({
+    // Changed get to _get
     ...getInitialState(useAppStore.getState().videoElement ?? undefined),
 
     handleInputChange: (payload) =>

--- a/src/stores/configurationPanelStore.ts
+++ b/src/stores/configurationPanelStore.ts
@@ -1,0 +1,175 @@
+import { create } from 'zustand';
+import { clamp } from '@/utils/clamp';
+import { log } from '@/utils/logger';
+import { useAppStore } from './appStore';
+
+const DEFAULT_WIDTH = 320;
+const DEFAULT_HEIGHT = 180;
+
+export interface ConfigState {
+  start: number;
+  duration: number;
+  width: number;
+  height: number;
+  linkDimensions: boolean;
+  framerate: number;
+  quality: number;
+  aspectRatio: number;
+  // Internal state, not directly user-configurable but affected by video loading
+  videoDuration: number;
+  videoWidth: number;
+  videoHeight: number;
+}
+
+// Action payloads
+type InputActionPayload = {
+  [K in keyof Pick<
+    ConfigState,
+    | 'start'
+    | 'duration'
+    | 'width'
+    | 'height'
+    | 'linkDimensions'
+    | 'framerate'
+    | 'quality'
+  >]: { name: K; value: ConfigState[K] };
+}[keyof Pick<
+  ConfigState,
+  | 'start'
+  | 'duration'
+  | 'width'
+  | 'height'
+  | 'linkDimensions'
+  | 'framerate'
+  | 'quality'
+>];
+
+interface VideoLoadedDataPayload {
+  aspectRatio: number;
+  duration: number;
+  videoWidth: number;
+  videoHeight: number;
+}
+
+interface VideoSeekedPayload {
+  currentTime: number;
+}
+
+interface SetStartToCurrentTimePayload {
+  currentTime: number;
+}
+
+// Store actions interface
+export interface ConfigActions {
+  handleInputChange: (payload: InputActionPayload) => void;
+  handleVideoLoadedData: (payload: VideoLoadedDataPayload) => void;
+  handleVideoSeeked: (payload: VideoSeekedPayload) => void; // Kept for potential future use, though not directly changing state in this version
+  handleSetStartToCurrentTime: (payload: SetStartToCurrentTimePayload) => void;
+  resetState: (videoElement?: HTMLVideoElement) => void;
+  // New action to handle seeking, as this involves an external element
+  seekVideo: (time: number) => void;
+}
+
+type ConfigurationPanelStore = ConfigState & ConfigActions;
+
+const getInitialState = (videoElement?: HTMLVideoElement): ConfigState => {
+  const aspectRatio = videoElement
+    ? videoElement.videoWidth / videoElement.videoHeight
+    : DEFAULT_WIDTH / DEFAULT_HEIGHT;
+  const initialWidth = videoElement?.videoWidth ?? DEFAULT_WIDTH;
+  const initialHeight = videoElement
+    ? Math.round(initialWidth / aspectRatio)
+    : DEFAULT_HEIGHT;
+
+  return {
+    start: videoElement?.currentTime ?? 0,
+    duration: 2,
+    width: initialWidth,
+    height: initialHeight,
+    linkDimensions: true,
+    framerate: 10,
+    quality: 5,
+    aspectRatio: isNaN(aspectRatio)
+      ? DEFAULT_WIDTH / DEFAULT_HEIGHT
+      : aspectRatio,
+    videoDuration: videoElement?.duration ?? 0,
+    videoWidth: videoElement?.videoWidth ?? 0,
+    videoHeight: videoElement?.videoHeight ?? 0
+  };
+};
+
+export const useConfigurationPanelStore = create<ConfigurationPanelStore>(
+  (set, _get) => ({ // Changed get to _get
+    ...getInitialState(useAppStore.getState().videoElement ?? undefined),
+
+    handleInputChange: (payload) =>
+      set((state) => {
+        const { name, value } = payload;
+        const newState = { ...state, [name]: value };
+
+        if (state.linkDimensions) {
+          if (name === 'width') {
+            newState.height = Math.round((value as number) / state.aspectRatio);
+          } else if (name === 'height') {
+            newState.width = Math.round((value as number) * state.aspectRatio);
+          }
+        }
+
+        if (name === 'linkDimensions' && value) {
+          newState.height = Math.round(state.width / state.aspectRatio);
+        }
+        return newState;
+      }),
+
+    handleVideoLoadedData: (payload) =>
+      set((state) => ({
+        ...state,
+        aspectRatio: payload.aspectRatio,
+        videoDuration: payload.duration,
+        videoWidth: payload.videoWidth,
+        videoHeight: payload.videoHeight,
+        // Recalculate height based on new aspect ratio if dimensions were default or linked
+        height:
+          state.linkDimensions || state.height === DEFAULT_HEIGHT
+            ? Math.round(state.width / payload.aspectRatio)
+            : state.height
+      })),
+
+    handleVideoSeeked: (_payload) => {
+      // This action might not directly change state if it's just for observation
+      // or triggering other effects. For now, it does nothing to the store state.
+      // log('Video seeked, current time:', payload.currentTime);
+    },
+
+    handleSetStartToCurrentTime: (payload) =>
+      set({ start: payload.currentTime }),
+
+    seekVideo: (time) => {
+      const videoElement = useAppStore.getState().videoElement;
+      if (videoElement) {
+        if (typeof time !== 'number' || time < 0 || isNaN(time)) {
+          log(`Could not seek to ${time}`);
+          return;
+        }
+        videoElement.currentTime = clamp(0, videoElement.duration, time);
+        videoElement.pause();
+      }
+    },
+
+    resetState: (videoElement?: HTMLVideoElement) => {
+      const newInitialState = getInitialState(
+        videoElement ?? useAppStore.getState().videoElement ?? undefined
+      );
+      set(newInitialState);
+    }
+  })
+);
+
+// Subscribe to videoElement changes in appStore to reset/update config panel state
+useAppStore.subscribe((state, prevState) => {
+  if (state.videoElement !== prevState.videoElement) {
+    useConfigurationPanelStore
+      .getState()
+      .resetState(state.videoElement ?? undefined);
+  }
+});

--- a/src/test-utils/testHelpers.ts
+++ b/src/test-utils/testHelpers.ts
@@ -1,0 +1,24 @@
+import { vi } from 'vitest';
+
+export const createMockVideoElement = (
+  currentTime = 0,
+  duration = 100,
+  videoWidth = 1280,
+  videoHeight = 720,
+  readyState = 1
+) => {
+  const videoElement = document.createElement('video');
+  vi.spyOn(videoElement, 'pause').mockImplementation(() => {});
+  vi.spyOn(videoElement, 'addEventListener').mockImplementation(() => {});
+  vi.spyOn(videoElement, 'removeEventListener').mockImplementation(() => {});
+
+  Object.defineProperties(videoElement, {
+    currentTime: { writable: true, value: currentTime },
+    duration: { writable: true, value: duration },
+    videoWidth: { writable: true, value: videoWidth },
+    videoHeight: { writable: true, value: videoHeight },
+    paused: { writable: true, value: true },
+    readyState: { writable: true, value: readyState } // 1 = HAVE_METADATA
+  });
+  return videoElement;
+};


### PR DESCRIPTION
- Created a new Zustand store in `configurationPanelStore.ts` to manage the state for the configuration panel.
- Refactored `ConfigurationPanel.tsx` to use this new store, separating UI logic from state management.
- Added unit tests for `configurationPanelStore.ts`.
- Updated unit tests for `ConfigurationPanel.tsx` to reflect the changes and ensure continued correctness with the new store-based state management.